### PR TITLE
attempt to fix tracker search issue

### DIFF
--- a/pages/Tracker_Search.md
+++ b/pages/Tracker_Search.md
@@ -5,21 +5,28 @@ title: Player Trackers
 <LastRefreshed prefix="Data last updated"/>
 
 ```sql trackers
-with tracker_search as (
-    SELECT * FROM trackers
-)
-select
-name,
-tracker,
-platform,
-platform_id as gamertag
-from tracker_search
-order by name
+
+SELECT
+    t.name
+    , CASE 
+        WHEN POSITION('[' IN t.tracker) > 0 AND POSITION(']' IN t.tracker) > 0 THEN 
+            SUBSTRING(t.tracker FROM POSITION('[' IN t.tracker) + 1 FOR POSITION(']' IN t.tracker) - POSITION('[' IN t.tracker) - 1)
+        ELSE 
+            t.tracker 
+    END AS cleaned_tracker
+    , t.platform
+    , t.platform_id as gamertag
+
+FROM trackers t
+
+ORDER BY
+    t.name
+
 ```
 
 
 <DataTable data={trackers} rows=20 rowShading=true search=true headerColor=#2a4b82 headerFontColor=white>
     <Column id=name />
-    <Column id=tracker contentType=link linkLabel=platform openInNewTab=true />
+    <Column id=cleaned_tracker contentType=link linkLabel=platform openInNewTab=true />
     <Column id=gamertag />
 </DataTable>


### PR DESCRIPTION
This CASE statement extracts the actual tracker link out of the weird markdown formatting that some of them are coming across in, hopefully to prevent the search bar from freaking out and taking down our whole build.

For the record, I do know that a regular expression would be better here and I had a wonderful clean solution that worked great in dbeaver, but due to escape characters being needed and then the regex no longer matching correctly once the escape characters were added, we went with this instead.  Here's the nicer CASE statement that works in dbeaver in case @ItsMeBrianD has some magical way to make it work in Evidence:

```
  CASE 
    WHEN pa.tracker ~ '\[([^\]]+)\]' THEN regexp_replace(pa.tracker, '.*\[(.*)\].*', '\1')
    ELSE pa.tracker 
  END AS cleaned_tracker
```