### PR TITLE
Post release clean-up

### DIFF
--- a/pages/Non-Rostered_Players.md
+++ b/pages/Non-Rostered_Players.md
@@ -29,7 +29,7 @@ WHERE franchise IN ('FA', 'Pend', 'Waivers', 'RFA');
 
 <Dropdown data={PWDropdown} name=Status value=franchise multiple=true selectAllByDefault=true />
 
->
+
 ```sql PWChart
 select
     franchise, 

--- a/pages/S18_Player_Stats.md
+++ b/pages/S18_Player_Stats.md
@@ -149,85 +149,6 @@ ORDER BY
 
 </Tab>
 
-<Tab label="Scrim Stats">
-
-```sql scrimStats
-with scrims as(
-SELECT 
-    p.name
-    , '/players/' || CAST(p.member_id AS INTEGER) as playerLink
-    , member_id
-    , p.salary
-    , CASE WHEN gamemode = 'RL_DOUBLES' THEN 'Doubles'
-        WHEN gamemode = 'RL_STANDARD' THEN 'Standard'
-        ELSE 'Unknown' 
-        END as game_mode
-    , p.skill_group as league
-    , franchise
-    , scrim_games_played
-    , win_percentage
-    , dpi_per_game as dpi
-    , opi_per_game as opi
-    , avg_sprocket_rating as sprocket_rating
-    , score_per_game as score
-    , goals_per_game as goals
-    , assists_per_game as assists
-    , saves_per_game as saves
-    , shots_per_game as shots
-    , avg_goals_against as goals_against
-    , avg_shots_against as shots_against
-    , demos_per_game as demos
-    , current_scrim_points as scrim_points
-    , "Eligible Until" as eligible_until
-FROM avgScrimStats ass 
-    LEFT JOIN players p 
-        ON p.sprocket_player_id = ass.sprocket_player_id)
-SELECT *
-From scrims
-WHERE salary in ${inputs.Salary.value}
-AND league in ${inputs.League.value}
-AND game_mode in ${inputs.GameMode.value}
-AND franchise in ${inputs.Team.value}
-```
-
-<Dropdown data={dropdown_info} name=Salary value=Salary multiple=true selectAllByDefault=true />
-
-<Dropdown data={dropdown_info} name=Team value=Team multiple=true selectAllByDefault=true />
-
-<Dropdown data={dropdown_info} name=League value=League multiple=true selectAllByDefault=true />
-
-<Dropdown data={dropdown_info} name=GameMode value=game_mode multiple=true selectAllByDefault=true />
-
-
-
->From Last 60 Days
-<DataTable data={scrimStats} rows=20 search=true rowShading=true headerColor=#2a4b82 headerFontColor=white link=playerLink >
-        <Column id=name align=center />
-        <Column id=salary align=center />
-        <Column id=game_mode align=center />
-        <Column id=league align=center />
-        <Column id=scrim_games_played align=center />
-        <Column id=win_percentage align=center />
-        <Column id=sprocket_rating align=center />
-        <Column id=opi align=center />
-        <Column id=dpi align=center />
-        <Column id=score align=ceneter />
-        <Column id=goals align=center />
-        <Column id=assists align=center />
-        <Column id=saves align=center />
-        <Column id=shots align=center />
-        <Column id=goals_against align=center />
-        <Column id=shots_against align=center />
-        <Column id=demos align=center />
-</DataTable>
-
-
-
-
-
-
-</Tab>
-
 <Tab label="Player Comparison">
 
 
@@ -295,7 +216,7 @@ where name in ${inputs.Player.value}
     <DropdownOption value=shooting_pct2 valueLabel="Shooting %" />
 </Dropdown>
 
-> Comparitive stats between players
+**Comparitive Stats between Players**
 <BarChart 
 data={comparisonStats}
 x=GameMode
@@ -378,7 +299,7 @@ from ${leagueStats}
     <DropdownOption value=Standard />
 </Dropdown>
 
-> ### {inputs.Stats.label} per League
+ ### {inputs.Stats.label} per League
 <BarChart data={leagueComparison}
 x=league
 y=value

--- a/pages/S18_Standings.md
+++ b/pages/S18_Standings.md
@@ -63,7 +63,7 @@ ORDER BY
 <Tabs>
 <Tab label="Overall Standings">
 
-## Overall Standings
+# Overall Standings
 
 ```sql overallStandings
 with S18standings as (

--- a/pages/Scrim_Stats.md
+++ b/pages/Scrim_Stats.md
@@ -1,0 +1,100 @@
+---
+title: Scrim Stats
+---
+
+<LastRefreshed prefix="Data last updated"/>
+
+<Details title='Instructions' open>
+
+Below you will find stats for scrims in MLE for S18 in the last 60 days.
+- You can use the search bar above the table to search for a specific player.
+- You can also use the drop down menus below to Filter the stats however you see fit.
+- Lastly you can click on the stat column to put stats in ascending or descending order.
+
+</Details>
+
+```sql dropdown_info
+
+SELECT DISTINCT 
+    p.franchise AS team
+    , ass.name
+    , ass.salary::TEXT AS salary
+    , ass.skill_group AS league
+    , CASE
+        WHEN ass.gamemode = 'RL_DOUBLES' THEN 'Doubles'
+        WHEN ass.gamemode = 'RL_STANDARD' THEN 'Standard'
+        ELSE 'Unknown'
+    END AS game_mode
+
+FROM avgScrimStats ass
+LEFT JOIN players p
+        ON p.sprocket_player_id = ass.sprocket_player_id
+
+```
+
+```sql scrimStats
+SELECT 
+    p.name
+    , '/players/' || CAST(p.member_id AS INTEGER) as playerLink
+    , p.member_id
+    , p.salary
+    , CASE WHEN ass.gamemode = 'RL_DOUBLES' THEN 'Doubles'
+        WHEN ass.gamemode = 'RL_STANDARD' THEN 'Standard'
+        ELSE 'Unknown' 
+        END as game_mode
+    , ass.skill_group as league
+    , p.franchise
+    , ass.scrim_games_played AS games_played
+    , ass.win_percentage AS win_pct
+    , ass.dpi_per_game as dpi
+    , ass.opi_per_game as opi
+    , ass.avg_sprocket_rating as sprocket_rating
+    , ass.score_per_game as score
+    , ass.goals_per_game as goals
+    , ass.assists_per_game as assists
+    , ass.saves_per_game as saves
+    , ass.shots_per_game as shots
+    , ass.avg_goals_against as goals_against
+    , ass.avg_shots_against as shots_against
+    , ass.demos_per_game as demos
+    , p.current_scrim_points as scrim_points
+    , p."Eligible Until" as eligible_until
+FROM avgScrimStats ass 
+    LEFT JOIN players p 
+        ON p.sprocket_player_id = ass.sprocket_player_id
+WHERE p.salary in ${inputs.Salary.value}
+AND ass.skill_group in ${inputs.League.value}
+AND game_mode in ${inputs.GameMode.value}
+AND p.franchise in ${inputs.Team.value}
+```
+
+<Dropdown data={dropdown_info} name=Salary value=Salary multiple=true selectAllByDefault=true />
+
+<Dropdown data={dropdown_info} name=Team value=Team multiple=true selectAllByDefault=true />
+
+<Dropdown data={dropdown_info} name=League value=League multiple=true selectAllByDefault=true />
+
+<Dropdown data={dropdown_info} name=GameMode value=game_mode multiple=true selectAllByDefault=true />
+
+
+
+## Scrim Stats from last 60 Days
+<DataTable data={scrimStats} rows=20 search=true rowShading=true headerColor=#2a4b82 headerFontColor=white link=playerLink >
+        <Column id=name align=center />
+        <Column id=salary align=center />
+        <Column id=game_mode align=center />
+        <Column id=league align=center />
+        <Column id=games_played align=center />
+        <Column id=win_pct align=center />
+        <Column id=sprocket_rating align=center />
+        <Column id=opi align=center />
+        <Column id=dpi align=center />
+        <Column id=score align=ceneter />
+        <Column id=goals align=center />
+        <Column id=assists align=center />
+        <Column id=saves align=center />
+        <Column id=shots align=center />
+        <Column id=goals_against align=center />
+        <Column id=shots_against align=center />
+        <Column id=demos align=center />
+</DataTable>

--- a/pages/players.md
+++ b/pages/players.md
@@ -6,13 +6,15 @@ SELECT
     franchise, 
     p.current_scrim_points,
     "Eligible Until"  
-from players p
-left join S18_stats s18
-    on p.member_id = s18.member_id
-group by name, salary, p.member_id, franchise, current_scrim_points, "Eligible Until"
+FROM players p
+LEFT JOIN S18_stats s18
+    ON p.member_id = s18.member_id
+WHERE salary <= 21.0 --filtering out TestUser1 & TestUser2 which have > 21.0 salaries
+AND NOT franchise = 'FP'
+GROUP BY name, salary, p.member_id, franchise, current_scrim_points, "Eligible Until"
 ```
 
-## Player Pages
+## Active Player Pages
 
 
 <LastRefreshed prefix="Data last updated"/>
@@ -33,6 +35,8 @@ SELECT
     , skill_group
     , count(*) as totalPlayers
 FROM players p
+WHERE salary <= 21.0 --filtering out TestUser1 & TestUser2 which have > 21.0 salaries
+AND NOT franchise = 'FP'
 GROUP BY
     salary
     , skill_group

--- a/pages/players/[member_id].md
+++ b/pages/players/[member_id].md
@@ -244,7 +244,7 @@ from seriesStats ss
 order by week asc 
 ```
 
->Season 18 Stats by Series
+Season 18 Stats by Series
 <DataTable data={playerSeries} rows=20 rowShading=true headerColor='{basic_info[0].primColor}' headerFontColor=white compact=true wrapTitles=true>
     <Column id=week align=center />
     <Column id=game_mode align=center />


### PR DESCRIPTION
Fixed TestUsers on Players page to represent salary distribution evenly

Fixed on S18 Stats and Player Page indents that made header color unreadable and not white.

Created Scrim Stats page and stole query from s18_player_stats page
	- Deleted Scrim stats from s18_player_stats

Consistency of heading size in S18_standsings page in Overall Standings to match other tabs

Updated Players tab to become "Active Players" tab in markdown name and adjusted queries to reflect only active players i.e. no FP. 