### PR TITLE
Fix playoff bracket tiebreaker bugs

### DIFF
--- a/components/PlayoffBracket.svelte
+++ b/components/PlayoffBracket.svelte
@@ -120,6 +120,39 @@
     function resolveCluster(tiedTeams) {
       if (tiedTeams.length <= 1) return tiedTeams;
 
+      // Rule 1.9 cross-division clause: "If multiple teams from the same division
+      // are involved in a tie ... with the other division, the highest ranked team
+      // from each division in the tie will be compared first. The team that loses
+      // the tie will then compare against the next highest team in the tie from
+      // the other division."
+      // Trigger: tied cluster spans 2+ divisions AND at least one division contains
+      // 2+ tied teams. Procedure: rank each division's tied teams internally, then
+      // iteratively pair the current top-of-each-division, seed the winner, and let
+      // the loser face the next candidate from the opposite division.
+      const divGroups = {};
+      for (const t of tiedTeams) {
+        const d = t.division ?? '_unknown';
+        if (!divGroups[d]) divGroups[d] = [];
+        divGroups[d].push(t);
+      }
+      const divNames = Object.keys(divGroups);
+      if (divNames.length > 1 && divNames.some(d => divGroups[d].length > 1)) {
+        const queues = {};
+        for (const d of divNames) queues[d] = resolveCluster(divGroups[d]);
+        const out = [];
+        while (true) {
+          const active = divNames.filter(d => queues[d].length > 0);
+          if (active.length === 0) break;
+          if (active.length === 1) { out.push(...queues[active[0]]); break; }
+          const candidates = active.map(d => queues[d][0]);
+          const ranked = resolveCluster(candidates);
+          const winner = ranked[0];
+          out.push(winner);
+          queues[winner.division ?? '_unknown'].shift();
+        }
+        return out;
+      }
+
       // Step 2: H2H
       if (tiedTeams.length === 2) {
         const pct = getH2HWinPct(tiedTeams[0].team_name, tiedTeams[1].team_name);

--- a/components/PlayoffBracket.svelte
+++ b/components/PlayoffBracket.svelte
@@ -32,125 +32,143 @@
   // Division leaders are guaranteed seeds 1–2; wildcards get seeds 3–4.
   // Within each group, teams are sorted by win% first, then tiebreakers resolve only
   // among teams with identical win%.
+  //
+  // h2h_records and division_records are passed explicitly into resolveTiebreakers so
+  // Svelte's static reactive-dep tracking re-runs the computation when those arrays
+  // arrive asynchronously — reading them via closure would miss the initial arrival
+  // and silently drop the H2H/division% steps. (Same pattern as roundGames below.)
 
-  // Returns teamA's game win percentage against teamB (0–1), or null if they never played.
-  function getH2HWinPct(teamA, teamB) {
-    let aWins = 0, bWins = 0;
-    const direct = h2h_records.find(r => r.team_a === teamA && r.team_b === teamB);
-    if (direct) { aWins += direct.a_game_wins; bWins += direct.b_game_wins; }
-    const reverse = h2h_records.find(r => r.team_a === teamB && r.team_b === teamA);
-    if (reverse) { aWins += reverse.b_game_wins; bWins += reverse.a_game_wins; }
-    if (aWins + bWins === 0) return null;
-    return aWins / (aWins + bWins);
-  }
-
-  function beatsAll(team, opponents) {
-    return opponents.every(opp => {
-      const pct = getH2HWinPct(team.team_name, opp.team_name);
-      return pct !== null && pct > 0.5;
-    });
-  }
-
-  function losesToAll(team, opponents) {
-    return opponents.every(opp => {
-      const pct = getH2HWinPct(team.team_name, opp.team_name);
-      return pct !== null && pct < 0.5;
-    });
-  }
-
-  // Multi-team H2H elimination (rules 1.9.2.1–1.9.2.3):
-  // Iteratively removes teams that beat ALL or lose to ALL others, then restarts.
-  function multiTeamH2H(teams) {
-    let remaining = [...teams];
-    let top = [], bottom = [];
-    let changed = true;
-    while (changed && remaining.length > 1) {
-      changed = false;
-      let newTop = [], newBottom = [];
-      // Rules 1.9.2.1 + 1.9.2.2 observed simultaneously (1.9.2.3)
-      for (const team of remaining) {
-        const others = remaining.filter(t => t !== team);
-        if (beatsAll(team, others)) newTop.push(team);
-        else if (losesToAll(team, others)) newBottom.push(team);
-      }
-      if (newTop.length > 0 || newBottom.length > 0) {
-        top.push(...newTop);
-        bottom.unshift(...newBottom);
-        remaining = remaining.filter(t => !newTop.includes(t) && !newBottom.includes(t));
-        changed = true;
-      }
-    }
-    return { top, bottom, remaining };
-  }
-
-  // Groups teams by a stat value (descending), returns array of arrays with equal values.
-  function groupByValue(teams, stat) {
-    if (teams.length === 0) return [];
-    const sorted = [...teams].sort((a, b) => (b[stat] ?? 0) - (a[stat] ?? 0));
-    const groups = [[sorted[0]]];
-    for (let i = 1; i < sorted.length; i++) {
-      if ((sorted[i][stat] ?? 0) === (groups[groups.length - 1][0][stat] ?? 0)) {
-        groups[groups.length - 1].push(sorted[i]);
-      } else {
-        groups.push([sorted[i]]);
-      }
-    }
-    return groups;
-  }
-
-  function allShareDivision(teams) {
-    const divs = new Set(teams.map(t => t.division).filter(Boolean));
-    return divs.size === 1;
-  }
-
-  function getDivWinPct(teamName) {
-    return division_records.find(r => r.team_name === teamName)?.div_win_pct ?? 0;
-  }
-
-  // Recursive tiebreaker resolution per rules 1.9.1-1.9.6.
-  // On any elimination the procedure restarts from the top (via recursion).
-  function resolveCluster(tiedTeams) {
-    if (tiedTeams.length <= 1) return tiedTeams;
-
-    // Step 2: H2H
-    if (tiedTeams.length === 2) {
-      const pct = getH2HWinPct(tiedTeams[0].team_name, tiedTeams[1].team_name);
-      if (pct !== null && pct !== 0.5) {
-        return pct > 0.5 ? [tiedTeams[0], tiedTeams[1]] : [tiedTeams[1], tiedTeams[0]];
-      }
-    } else {
-      const { top, bottom, remaining } = multiTeamH2H(tiedTeams);
-      if (top.length > 0 || bottom.length > 0) {
-        return [...top, ...resolveCluster(remaining), ...bottom];
-      }
-    }
-
-    // Step 3: Series win %
-    const bySeries = groupByValue(tiedTeams, 'series_win_pct');
-    if (bySeries.length > 1) return bySeries.flatMap(g => resolveCluster(g));
-
-    // Step 4: Division game win % (only if all tied teams share a division)
-    if (allShareDivision(tiedTeams)) {
-      const withDiv = tiedTeams.map(t => ({ ...t, _dwp: getDivWinPct(t.team_name) }));
-      const byDiv = groupByValue(withDiv, '_dwp');
-      if (byDiv.length > 1) return byDiv.flatMap(g => resolveCluster(g));
-    }
-
-    // Step 5: Goal differential
-    const byGD = groupByValue(tiedTeams, 'goal_differential');
-    if (byGD.length > 1) return byGD.flatMap(g => resolveCluster(g));
-
-    // Step 6: Goals for
-    const byGF = groupByValue(tiedTeams, 'goals_for');
-    if (byGF.length > 1) return byGF.flatMap(g => resolveCluster(g));
-
-    return tiedTeams;
-  }
-
-  // Main entry point: partitions seeds by conference or super_division, then resolves
-  // seeding within each partition. Leaders (div winners) are ranked first, then wildcards.
-  function resolveTiebreakers(seeds, is16Team) {
+  function resolveTiebreakers(seeds, is16Team, h2h, divRecords) {
     if (!seeds || seeds.length === 0) return [];
+
+    // Returns teamA's game win percentage against teamB (0–1), or null if they never played.
+    function getH2HWinPct(teamA, teamB) {
+      let aWins = 0, bWins = 0;
+      const direct = (h2h || []).find(r => r.team_a === teamA && r.team_b === teamB);
+      if (direct) { aWins += direct.a_game_wins; bWins += direct.b_game_wins; }
+      const reverse = (h2h || []).find(r => r.team_a === teamB && r.team_b === teamA);
+      if (reverse) { aWins += reverse.b_game_wins; bWins += reverse.a_game_wins; }
+      if (aWins + bWins === 0) return null;
+      return aWins / (aWins + bWins);
+    }
+
+    function beatsAll(team, opponents) {
+      return opponents.every(opp => {
+        const pct = getH2HWinPct(team.team_name, opp.team_name);
+        return pct !== null && pct > 0.5;
+      });
+    }
+
+    function losesToAll(team, opponents) {
+      return opponents.every(opp => {
+        const pct = getH2HWinPct(team.team_name, opp.team_name);
+        return pct !== null && pct < 0.5;
+      });
+    }
+
+    // Multi-team H2H elimination (rules 1.9.2.1–1.9.2.3):
+    // Iteratively removes teams that beat ALL or lose to ALL others, then restarts.
+    function multiTeamH2H(teams) {
+      let remaining = [...teams];
+      let top = [], bottom = [];
+      let changed = true;
+      while (changed && remaining.length > 1) {
+        changed = false;
+        let newTop = [], newBottom = [];
+        // Rules 1.9.2.1 + 1.9.2.2 observed simultaneously (1.9.2.3)
+        for (const team of remaining) {
+          const others = remaining.filter(t => t !== team);
+          if (beatsAll(team, others)) newTop.push(team);
+          else if (losesToAll(team, others)) newBottom.push(team);
+        }
+        if (newTop.length > 0 || newBottom.length > 0) {
+          top.push(...newTop);
+          bottom.unshift(...newBottom);
+          remaining = remaining.filter(t => !newTop.includes(t) && !newBottom.includes(t));
+          changed = true;
+        }
+      }
+      return { top, bottom, remaining };
+    }
+
+    // Groups teams by a stat value (descending), returns array of arrays with equal values.
+    function groupByValue(teams, stat) {
+      if (teams.length === 0) return [];
+      const sorted = [...teams].sort((a, b) => (b[stat] ?? 0) - (a[stat] ?? 0));
+      const groups = [[sorted[0]]];
+      for (let i = 1; i < sorted.length; i++) {
+        if ((sorted[i][stat] ?? 0) === (groups[groups.length - 1][0][stat] ?? 0)) {
+          groups[groups.length - 1].push(sorted[i]);
+        } else {
+          groups.push([sorted[i]]);
+        }
+      }
+      return groups;
+    }
+
+    function allShareDivision(teams) {
+      const divs = new Set(teams.map(t => t.division).filter(Boolean));
+      return divs.size === 1;
+    }
+
+    function getDivWinPct(teamName) {
+      return (divRecords || []).find(r => r.team_name === teamName)?.div_win_pct ?? 0;
+    }
+
+    // Recursive tiebreaker resolution per rules 1.9.1-1.9.6.
+    // On any elimination the procedure restarts from the top (via recursion).
+    function resolveCluster(tiedTeams) {
+      if (tiedTeams.length <= 1) return tiedTeams;
+
+      // Step 2: H2H
+      if (tiedTeams.length === 2) {
+        const pct = getH2HWinPct(tiedTeams[0].team_name, tiedTeams[1].team_name);
+        if (pct !== null && pct !== 0.5) {
+          return pct > 0.5 ? [tiedTeams[0], tiedTeams[1]] : [tiedTeams[1], tiedTeams[0]];
+        }
+      } else {
+        const { top, bottom, remaining } = multiTeamH2H(tiedTeams);
+        if (top.length > 0 || bottom.length > 0) {
+          return [...top, ...resolveCluster(remaining), ...bottom];
+        }
+      }
+
+      // Step 3: Series win %
+      const bySeries = groupByValue(tiedTeams, 'series_win_pct');
+      if (bySeries.length > 1) return bySeries.flatMap(g => resolveCluster(g));
+
+      // Step 4: Division game win % (only if all tied teams share a division)
+      if (allShareDivision(tiedTeams)) {
+        const withDiv = tiedTeams.map(t => ({ ...t, _dwp: getDivWinPct(t.team_name) }));
+        const byDiv = groupByValue(withDiv, '_dwp');
+        if (byDiv.length > 1) return byDiv.flatMap(g => resolveCluster(g));
+      }
+
+      // Step 5: Goal differential
+      const byGD = groupByValue(tiedTeams, 'goal_differential');
+      if (byGD.length > 1) return byGD.flatMap(g => resolveCluster(g));
+
+      // Step 6: Goals for
+      const byGF = groupByValue(tiedTeams, 'goals_for');
+      if (byGF.length > 1) return byGF.flatMap(g => resolveCluster(g));
+
+      return tiedTeams;
+    }
+
+    function resolveGroup(teams) {
+      if (teams.length <= 1) return teams;
+      const byWinPct = groupByValue(teams, 'win_pct');
+      return byWinPct.flatMap(g => g.length === 1 ? g : resolveCluster(g));
+    }
+
+    // Partition seeds by conference or super_division. Within each partition, the
+    // rules require division standings to be decided FIRST: run the full tiebreaker
+    // procedure inside each division to pick its winner (guaranteed a top seed),
+    // then rank the division winners among themselves and the non-winners among
+    // themselves using the same procedure. The SQL `is_divisional_leader` flag is
+    // ignored here because it comes from an external standings table that doesn't
+    // apply the H2H step — e.g. when two teams in one division tie on wins, SQL
+    // may crown the wrong team as leader.
     const partKey = is16Team ? 'conference' : 'super_division';
     const groups = {};
     for (const t of seeds) {
@@ -158,26 +176,32 @@
       if (!groups[k]) groups[k] = [];
       groups[k].push(t);
     }
-    // Sort by win_pct first, then only apply tiebreakers within same win_pct
-    function resolveGroup(teams) {
-      if (teams.length <= 1) return teams;
-      const byWinPct = groupByValue(teams, 'win_pct');
-      return byWinPct.flatMap(g => g.length === 1 ? g : resolveCluster(g));
-    }
 
     const result = [];
     for (const teams of Object.values(groups)) {
-      const leaders = teams.filter(t => t.is_divisional_leader == 1);
-      const others = teams.filter(t => t.is_divisional_leader != 1);
-      const resolved = [...resolveGroup(leaders), ...resolveGroup(others)];
+      const divisions = {};
+      for (const t of teams) {
+        const d = t.division ?? 'unknown';
+        if (!divisions[d]) divisions[d] = [];
+        divisions[d].push(t);
+      }
+      const leaders = [];
+      const nonLeaders = [];
+      for (const divTeams of Object.values(divisions)) {
+        const ranked = resolveGroup(divTeams);
+        leaders.push(ranked[0]);
+        nonLeaders.push(...ranked.slice(1));
+      }
+      const resolved = [...resolveGroup(leaders), ...resolveGroup(nonLeaders)];
       result.push(...resolved.map((t, i) => ({ ...t, resolved_rank: i + 1 })));
     }
     return result;
   }
 
   // ===== Resolved Seeds =====
-  // Pass is16 explicitly so Svelte tracks the dependency on both playoff_seeds and is16
-  $: resolvedSeeds = resolveTiebreakers(playoff_seeds, is16);
+  // h2h_records and division_records are passed explicitly so Svelte re-runs this
+  // when either arrives after playoff_seeds (see comment on resolveTiebreakers).
+  $: resolvedSeeds = resolveTiebreakers(playoff_seeds, is16, h2h_records, division_records);
 
   // ===== Shared Helpers =====
   // Note: seed lookups below reference resolvedSeeds directly in the $: expression

--- a/pages/season/playoffs.md
+++ b/pages/season/playoffs.md
@@ -22,10 +22,11 @@ sidebar_position: 3
     <ButtonGroupItem valueLabel="Standard" value="Standard" />
 </ButtonGroup>
 
-<!-- Playoff seeds: calculates seeding for each league/mode combination.
+<!-- Playoff seeds: returns ALL eligible teams per partition (no seed_rank cutoff).
+     Full tiebreaker resolution (H2H, division%) happens in JS — cutting at 4 here
+     would drop teams that tie on win% outside the top 4 before H2H can promote them.
      Partitions by conference (16-team) or super_division (32-team).
-     Division leaders get seeds 1-2, wildcards get 3-4.
-     Ordered by: divisional leader status, win%, series win%, goal diff, goals for. -->
+     Division leaders get seeds 1-2, wildcards get 3-4. -->
 
 ```sql playoff_seeds
 WITH S19standings AS (
@@ -139,7 +140,6 @@ ranked AS (
     FROM staging
 )
 SELECT * FROM ranked
-WHERE seed_rank <= 4
 ORDER BY conference, super_division, seed_rank
 ```
 


### PR DESCRIPTION
## Summary

Fixes multiple bugs in the playoff bracket tiebreaker engine where teams were being seeded incorrectly when tied on win%. The engine now correctly applies MLE rules 1.9.1-1.9.6 including the rule 1.9 preamble cross-division procedure.

## Changes

- **Remove SQL `seed_rank <= 4` cutoff** (`pages/season/playoffs.md`): The SQL ordering only knew win%, series%, and goal diff — it didn't apply H2H or division%. Pre-filtering to the top 4 seeds could drop a team tied at the 4/5 boundary before JS could promote it via H2H.
- **Thread `h2h_records` and `division_records` as explicit params** (`components/PlayoffBracket.svelte`): These arrays were captured by closure inside helpers, so Svelte's static dep tracking never re-ran `resolvedSeeds` when they arrived async. H2H silently returned null and the cluster fell through to series%. Nesting helpers inside `resolveTiebreakers(seeds, is16, h2h, divRecords)` makes the reactivity explicit.
- **Compute division leaders in JS instead of trusting `is_divisional_leader`**: The SQL flag came from an external standings table that also didn't apply H2H. When two same-division teams tied on wins, the wrong team could be crowned division leader. Division winners are now determined by running the full tiebreaker on each division.
- **Add rule 1.9 cross-division procedure inside `resolveCluster`**: When a tied cluster spans multiple divisions with 2+ teams in at least one, pair the top-remaining team from each division, winner advances, loser faces the next team from the opposite division. Falls through to the normal tiebreaker cascade within each pairing.

## Reasoning

The root cause of three of the four bugs was that tiebreaker information (H2H, division records) was computed in SQL but never actually consulted in the ordering — either because SQL couldn't express the rule, or because Svelte reactivity dropped the data. Moving all tiebreaker resolution into JS with explicit parameter passing makes the rule application deterministic and debuggable. The cross-division procedure is a structural rule that only activates for multi-division ties, so it lives as a branch at the top of `resolveCluster` before the normal cascade.

## Test plan

- [x] Master League Doubles: Dodgers/Hawks tied 26-24, Hawks won H2H 4-1 → Hawks seeded ahead
- [x] Premier League Standard: Rhinos/Express tied 27-23, Rhinos won H2H 4-1 → Rhinos seeded ahead
- [x] Foundation Doubles 3-way tie (Tyrants/Foxes/Wizards at 27-23): Tyrants and Foxes share a division, Tyrants beat Foxes 9-1 → Tyrants is division leader, Foxes/Wizards resolved as wildcards
- [x] Premier Standard 3-way cross-division tie (Wolves/Jets/Hive at 26-24): Wolves in Storm, Jets+Hive in Sky → Wolves=4, Jets=5, Hive=6 via cross-division pairing
- [x] Regression: Lightning/Blizzard tiebreak still resolves correctly